### PR TITLE
Update spec

### DIFF
--- a/lib/bertex.ex
+++ b/lib/bertex.ex
@@ -56,12 +56,6 @@ defmodule Bertex do
     end
   end
 
-  defimpl Bert, for: HashDict do
-    def encode(dict), do: {:bert, :dict, Map.to_list(dict)}
-    # This should never happen.
-    def decode(dict), do: Enum.into(dict, %{})
-  end
-
   defimpl Bert, for: Any do
     def encode(term), do: term
     def decode(term), do: term

--- a/lib/bertex.ex
+++ b/lib/bertex.ex
@@ -55,12 +55,6 @@ defmodule Bertex do
     end
   end
 
-  defimpl Bert, for: Map do
-    def encode(dict), do: {:bert, :dict, Map.to_list(dict)}
-    # This should never happen.
-    def decode(dict), do: Enum.into(dict, %{})
-  end
-
   defimpl Bert, for: HashDict do
     def encode(dict), do: {:bert, :dict, Map.to_list(dict)}
     # This should never happen.

--- a/lib/bertex.ex
+++ b/lib/bertex.ex
@@ -16,13 +16,14 @@ defmodule Bertex do
   defimpl Bert, for: Atom do
     def encode(false), do: {:bert, false}
     def encode(true), do: {:bert, true}
+    def encode(nil), do: {:bert, nil}
+
     def encode(atom), do: atom
 
     def decode(atom), do: atom
   end
 
   defimpl Bert, for: List do
-    def encode([]), do: {:bert, nil}
     def encode(list) do
       Enum.map(list, &Bert.encode(&1))
     end
@@ -40,7 +41,7 @@ defmodule Bertex do
         |> List.to_tuple
     end
 
-    def decode({:bert, nil}), do: []
+    def decode({:bert, nil}), do: nil
 
     def decode({:bert, true}), do: true
 

--- a/test/bertex_test.exs
+++ b/test/bertex_test.exs
@@ -38,8 +38,8 @@ defmodule Bertex.Test do
     assert binary_to_term(encode(:atom)) == :atom
   end
 
-  test "encode empty list" do
-    assert binary_to_term(encode([])) == {:bert, nil}
+  test "encode nil" do
+    assert binary_to_term(encode(nil)) == {:bert, nil}
   end
 
   test "encode list" do
@@ -76,8 +76,8 @@ defmodule Bertex.Test do
     assert decode(term_to_binary(:atom)) == :atom
   end
 
-  test "decode empty list" do
-    assert decode(term_to_binary({:bert, nil})) == []
+  test "decode nil" do
+    assert decode(term_to_binary({:bert, nil})) == nil
   end
 
   test "decode list" do

--- a/test/bertex_test.exs
+++ b/test/bertex_test.exs
@@ -49,7 +49,7 @@ defmodule Bertex.Test do
   test "encode map" do
     dict = %{}
       |> Map.put(:key, "value")
-    assert binary_to_term(encode(dict)) == {:bert, :dict, key: "value"}
+    assert binary_to_term(encode(dict)) == %{key: "value"}
   end
 
   test "decode true" do
@@ -84,17 +84,10 @@ defmodule Bertex.Test do
     assert decode(term_to_binary([1, 2, 3])) == [1, 2, 3]
   end
 
-  test "decode dict" do
+  test "decode map" do
     dict = %{}
       |> Map.put(:key, "value")
-    assert decode(term_to_binary({:bert, :dict, key: "value"})) == dict
-  end
-
-  test "decode complex Map" do
-    dict = %{}
-      |> Map.put(:key, "value")
-      |> Map.put(:key2, false)
-    assert decode(term_to_binary({:bert, :dict, key: "value", key2: {:bert, false}})) == dict
+    assert decode(term_to_binary(%{key: "value"})) == dict
   end
 
   test "encode/decode true" do

--- a/test/bertex_test.exs
+++ b/test/bertex_test.exs
@@ -141,4 +141,25 @@ defmodule Bertex.Test do
     assert_raise ArgumentError,  fn -> safe_decode(binary_rep_to_unknown_atom) end
   end
 
+  test "encode naive date time" do
+    {:ok, date} = NaiveDateTime.new(2009, 10, 11, 14, 12, 1, {0, 6})
+    assert binary_to_term(encode(date)) == {:bert, :time, 1255, 270321, 0}
+  end
+
+  test "encode date time" do
+    {:ok, naive} = NaiveDateTime.new(2009, 10, 11, 14, 12, 1, {0, 6})
+    {:ok, date} = DateTime.from_naive(naive, "Etc/UTC")
+    assert binary_to_term(encode(date)) == {:bert, :time, 1255, 270321, 0}
+  end
+
+  test "encode date" do
+    {:ok, date} = Date.new(2009, 10, 11)
+    assert binary_to_term(encode(date)) == {:bert, :time, 1255, 219200, 0}
+  end
+
+  test "decode date time" do
+    {:ok, naive} = NaiveDateTime.new(2009, 10, 11, 14, 12, 1, {0, 6})
+    {:ok, date} = DateTime.from_naive(naive, "Etc/UTC")
+    assert decode(term_to_binary({:bert, :time, 1255, 270321, 0})) == date
+  end
 end


### PR DESCRIPTION
This PR introduces the following changes:

* Add date types support
* Fix nil/empty list encoding
* Natively encode maps/structs with Erlang's ETF

You can read more about them in the commit log.

About the last one, when BERT spec was drafted, Erlang didn't have
support for maps. I guess that it was introduced to support Elixir properly.
As it has now, it makes sense to use the native encoding (MAP_EXT).