### PR TITLE
Refuse to encode/decode functions

### DIFF
--- a/lib/bertex.ex
+++ b/lib/bertex.ex
@@ -99,8 +99,8 @@ defmodule Bertex do
   end
 
   defimpl Bert, for: Any do
-    def encode(term), do: term
-    def decode(term), do: term
+    def encode(term) when is_integer(term) or is_float(term) or is_binary(term) or is_map(term), do: term
+    def decode(term) when is_integer(term) or is_float(term) or is_binary(term) or is_map(term), do: term
   end
 
   @doc """

--- a/test/bertex_test.exs
+++ b/test/bertex_test.exs
@@ -162,4 +162,12 @@ defmodule Bertex.Test do
     {:ok, date} = DateTime.from_naive(naive, "Etc/UTC")
     assert decode(term_to_binary({:bert, :time, 1255, 270321, 0})) == date
   end
+
+  test "refuses to encode a function" do
+    catch_error(encode(fn x -> x end))
+  end
+
+  test "refuses to decode a function" do
+    catch_error(decode(term_to_binary(fn x -> x + 1 end)))
+  end
 end


### PR DESCRIPTION
Avoids security vulnerabilities when decoding untrusted inputs, potentially resulting in arbitrary code execution, similar to CVE-2020-15150.

Proof of concept:

```elixir
"g3AAAAGUArmNguoOmUJOwZi4O+mUWk8AAAArAAAAAWQACGVybF9ldmFsYStiBcxsF1hkAA1ub25vZGVAbm9ob3N0AAAArgAAAAAAAAAAaARqZAAEbm9uZWQABG5vbmVsAAAAAWgFZAAGY2xhdXNlYQVsAAAAAmgDZAAFdHVwbGVhAGwAAAACaANkAARhdG9tYQBkAARjb250aANkAAN2YXJhBWQABF94QDFqaANkAAN2YXJhBWQAAV9qamwAAAACaARkAARjYWxsYQVoBGQABnJlbW90ZWEFaANkAARhdG9tYQBkAA1FbGl4aXIuU3lzdGVtaANkAARhdG9tYQVkAANjbWRsAAAAAmgDZAADYmluYQBsAAAAAWgFZAALYmluX2VsZW1lbnRhAGgDZAAGc3RyaW5nYQBrAAV4Y2FsY2QAB2RlZmF1bHRkAAdkZWZhdWx0amgCZAADbmlsYQBqaANkAAV0dXBsZWEAbAAAAAJoA2QABGF0b21hAGQABGRvbmVoA2QAA3ZhcmEFZAAEX3hAMWpqag==" |> Base.decode64!() |> Bertex.decode() |> Enum.count()
```

will open `xcalc` when executed on a Linux system that has it.